### PR TITLE
any::rstac in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,6 +29,7 @@ jobs:
               any::devtools
               any::DT
               any::htmltools
+              any::rstac
             needs: coverage
 
       - name: Cache C++ and R dependencies


### PR DESCRIPTION
rstac dependency in the test coverage portion of pkgdown deployment workflow