### PR TITLE
calculate_ecoregion bug fix

### DIFF
--- a/R/calculate_covariates.R
+++ b/R/calculate_covariates.R
@@ -553,19 +553,20 @@ calculate_ecoregion <-
     colnames(df_lv3) <- key3_num_unique
 
     locs_ecoreg <- cbind(
-      locs_df[(locs_df[,1] %in% extracted[[locs_id]][,1]), ],
+      locs_df[(locs_df[, 1] %in% extracted[[locs_id]][, 1]), ],
       paste0("1997 - ", data.table::year(Sys.Date())),
       df_lv2, df_lv3
     )
-    colnames(locs_ecoreg)[1]=locs_id 
-    
+    colnames(locs_ecoreg)[1] <- locs_id
+
     # Catch and patch for sites with no matching ecoregions
-    if(nrow (locs_ecoreg) != nrow(locs)){
-    message("Warning: only ", nrow(locs_ecoreg), " of the ", nrow(locs),
-    " locations provided had matching ecoregions. ", nrow(locs)-nrow(locs_ecoreg)," unmatched locations
-    will present NAs.")
-    # Introduce missing sites back to dataframe
-    locs_ecoreg <- merge(locs_df,locs_ecoreg, by=locs_id, all.x=TRUE)
+    if (nrow(locs_ecoreg) != nrow(locs)) {
+      message("Warning: only ", nrow(locs_ecoreg), " of the ", nrow(locs),
+              " locations provided had matching ecoregions. ",
+              nrow(locs) - nrow(locs_ecoreg),
+              " unmatched locations will present NAs.")
+      # Introduce missing sites back to dataframe
+      locs_ecoreg <- merge(locs_df, locs_ecoreg, by = locs_id, all.x = TRUE)
     }
     locs_return <- calc_return_locs(
       covar = locs_ecoreg,

--- a/R/calculate_covariates.R
+++ b/R/calculate_covariates.R
@@ -553,10 +553,20 @@ calculate_ecoregion <-
     colnames(df_lv3) <- key3_num_unique
 
     locs_ecoreg <- cbind(
-      locs_df,
+      locs_df[(locs_df[,1] %in% extracted[[locs_id]][,1]), ],
       paste0("1997 - ", data.table::year(Sys.Date())),
       df_lv2, df_lv3
     )
+    colnames(locs_ecoreg)[1]=locs_id 
+    
+    # Catch and patch for sites with no matching ecoregions
+    if(nrow (locs_ecoreg) != nrow(locs)){
+    message("Warning: only ", nrow(locs_ecoreg), " of the ", nrow(locs),
+    " locations provided had matching ecoregions. ", nrow(locs)-nrow(locs_ecoreg)," unmatched locations
+    will present NAs.")
+    # Introduce missing sites back to dataframe
+    locs_ecoreg <- merge(locs_df,locs_ecoreg, by=locs_id, all.x=TRUE)
+    }
     locs_return <- calc_return_locs(
       covar = locs_ecoreg,
       POSIXt = FALSE,

--- a/tests/testthat/test-ecoregion.R
+++ b/tests/testthat/test-ecoregion.R
@@ -245,5 +245,7 @@ testthat::test_that("calculate_ecoregion", {
       geom = TRUE
     )
   )
+  # Ensure that unmatched locations are handled properly
+  testthat::expect_true(nrow(ecor_res) == nrow(site_faux))
 })
 # nolint end


### PR DESCRIPTION
A few lines to fix issue with `terra::intersect()` not matching all the input sites. The update will merge the unmatched sites back to the final output with `NA` on the covariate rows, and give the user a warning message listing how many sites will present `NA`s.