### PR TITLE
1.2.4.2

### DIFF
--- a/.github/workflows/test-coverage.R
+++ b/.github/workflows/test-coverage.R
@@ -2,14 +2,18 @@ args <- commandArgs(trailingOnly = TRUE)
 runnertemp <- args[[1]]
 ghworkspace <- args[[2]]
 
-dir.create(file.path(runnertemp, "package"), showWarnings = FALSE, recursive = TRUE)
-sink(paste0(runnertemp, '/package/testthat.Rout.res'))
+dir.create(
+  file.path(runnertemp, "package"),
+  showWarnings = FALSE,
+  recursive = TRUE
+)
+sink(paste0(runnertemp, "/package/testthat.Rout.res"))
 cov <- covr::package_coverage(quiet = FALSE)
 sink()
 covd <- covr::coverage_to_list(cov)$totalcoverage
 write.table(
   covd[length(covd)],
-  file = file.path(ghworkspace, 'local_cov.Rout'),
+  file = file.path(ghworkspace, "local_cov.Rout"),
   row.names = FALSE,
   col.names = FALSE
 )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: amadeus
 Title: Accessing and Analyzing Large-Scale Environmental Data
-Version: 1.2.4
+Version: 1.2.4.2
 Authors@R: c(
     person(given = "Mitchell", family = "Manware", role = c("aut", "ctb"), comment = c(ORCID = "0009-0003-6440-6106")),
     person(given = "Insang", family = "Song", role = c("aut", "ctb"), comment = c(ORCID = "0000-0001-8732-3256")),

--- a/R/calculate_covariates.R
+++ b/R/calculate_covariates.R
@@ -430,14 +430,15 @@ calculate_nlcd <- function(
   cfpath <- system.file("extdata", "nlcd_classes.csv", package = "amadeus")
   nlcd_classes <- utils::read.csv(cfpath)
 
-  if (radius <= 0 && terra::geomtype(locs) == "points") {
-    message(
-      paste0(
-        "Calculating NLCD Land Cover Class covariates for ",
-        year,
-        "..."
-      )
+  message(
+    paste0(
+      "Calculating NLCD Land Cover Class covariates for ",
+      year,
+      "..."
     )
+  )
+
+  if (radius <= 0 && terra::geomtype(locs) == "points") {
     new_data_vect <- suppressMessages(
       amadeus::calc_worker(
         dataset = "nlcd",
@@ -462,7 +463,7 @@ calculate_nlcd <- function(
     bufs_pol <- terra::buffer(data_vect_b, width = radius)
     if (mode == "terra") {
       # terra mode
-      class_query <- "names"
+      # class_query <- "names"
       # extract land cover class in each buffer
       nlcd_at_bufs <- Map(
         function(i) {
@@ -484,7 +485,7 @@ calculate_nlcd <- function(
       nlcd_cellcnt <- nlcd_cellcnt / rowSums(nlcd_cellcnt, na.rm = TRUE)
       nlcd_at_bufs_fill[, seq(1, ncol(nlcd_at_bufs_fill), 1)] <- nlcd_cellcnt
     } else {
-      class_query <- "value"
+      # class_query <- "value"
       # ratio of each nlcd class per buffer
       bufs_polx <- bufs_pol[terra::ext(from), ] |>
         sf::st_as_sf()
@@ -515,6 +516,7 @@ calculate_nlcd <- function(
         grep("^frac_", nlcd_at_buf_names)
       nlcd_at_bufs_fill <- nlcd_at_bufs_fill[, nlcd_val_cols]
     }
+
     # fill NAs
     nlcd_at_bufs_fill[is.na(nlcd_at_bufs_fill)] <- 0
     # change column names
@@ -527,7 +529,7 @@ calculate_nlcd <- function(
         terra = nlcd_names
       )
     nlcd_names <-
-      nlcd_classes$class[match(nlcd_names, nlcd_classes[[class_query]])]
+      nlcd_classes$class[match(nlcd_names, nlcd_classes$value)]
     new_names <- sprintf("LDU_%s_0_%05d", nlcd_names, radius)
     names(nlcd_at_bufs_fill) <- new_names
 

--- a/R/download.R
+++ b/R/download.R
@@ -171,7 +171,7 @@ download_data <-
 #'  Currently, no value other than `"daily"` works.
 #' @param url_aqs_download character(1).
 #'  URL to the AQS pre-generated datasets.
-#' @param year character(1 or 2). length of 4. Year or start/end years for downloading data.
+#' @param year integer(1 or 2). length of 4. Year or start/end years for downloading data.
 #' @param directory_to_save character(1). Directory to save data. Two
 #' sub-directories will be created for the downloaded zip files ("/zip_files")
 #' and the unzipped data files ("/data_files").
@@ -1382,7 +1382,7 @@ download_merra2 <- function(
 #' @note "Pressure levels" variables contain variable values at 29 atmospheric levels, ranging from 1000 hPa to 100 hPa. All pressure levels data will be downloaded for each variable.
 #' @param variables character. Variable(s) name acronym. See [List of Variables in NARR Files](https://ftp.cpc.ncep.noaa.gov/NARR/fixed/merged_land_AWIP32corrected.pdf)
 #' for variable names and acronym codes.
-#' @param year character(1 or 2). length of 4. Year or start/end years for downloading data.
+#' @param year integer(1 or 2). length of 4. Year or start/end years for downloading data.
 #' @param directory_to_save character(1). Directory(s) to save downloaded data
 #' files.
 #' @param acknowledgement logical(1). By setting \code{TRUE} the
@@ -2848,7 +2848,7 @@ download_modis <- function(
 #' Download toxic release data
 #' @description
 #' The \code{download_tri()} function accesses and downloads toxic release data from the [U.S. Environmental Protection Agency's (EPA) Toxic Release Inventory (TRI) Program](https://www.epa.gov/toxics-release-inventory-tri-program/tri-data-action-0).
-#' @param year character(1 or 2). length of 4. Year or start/end years for downloading data.
+#' @param year integer(1 or 2). length of 4. Year or start/end years for downloading data.
 # nolint end
 #' @param directory_to_save character(1). Directory to download files.
 #' @param acknowledgement logical(1). By setting \code{TRUE} the
@@ -2963,7 +2963,7 @@ download_tri <- function(
 #' 'extdata/cacert_gaftp_epa.pem' under the package installation path.
 #' @param certificate_url character(1). URL to certificate file. See notes for
 #' details.
-#' @param year Available years of NEI data.
+#' @param year integer(1) Available years of NEI data.
 #' Default is \code{c(2017L, 2020L)}.
 #' @param directory_to_save character(1). Directory to save data. Two
 #' sub-directories will be created for the downloaded zip files ("/zip_files")
@@ -3581,7 +3581,7 @@ download_prism <- function(
 #' @param variables character(1). Variable(s) name(s). See [gridMET Generate Wget File](https://www.climatologylab.org/wget-gridmet.html)
 #' for variable names and acronym codes. (Note: variable "Burning Index" has code "bi" and variable
 #' "Energy Release Component" has code "erc").
-#' @param year character(1 or 2). length of 4. Year or start/end years for downloading data.
+#' @param year integer(1 or 2). length of 4. Year or start/end years for downloading data.
 #' @param directory_to_save character(1). Directory(s) to save downloaded data
 #' files.
 #' @param acknowledgement logical(1). By setting \code{TRUE} the
@@ -3727,7 +3727,7 @@ download_gridmet <- function(
 #' The \code{download_terraclimate} function accesses and downloads climate and water balance data from the [University of California Merced Climatology Lab's TerraClimate dataset](https://www.climatologylab.org/terraclimate.html).
 #' @param variables character(1). Variable(s) name(s). See [TerraClimate Direct Downloads](https://climate.northwestknowledge.net/TERRACLIMATE/index_directDownloads.php)
 #' for variable names and acronym codes.
-#' @param year character(1 or 2). length of 4. Year or start/end years for downloading data.
+#' @param year integer(1 or 2). length of 4. Year or start/end years for downloading data.
 #' @param directory_to_save character(1). Directory(s) to save downloaded data
 #' files.
 #' @param acknowledgement logical(1). By setting \code{TRUE} the

--- a/R/download.R
+++ b/R/download.R
@@ -233,7 +233,9 @@ download_aqs <-
     #### 2. check for null parameters
     amadeus::check_for_null_parameters(mget(ls()))
     #### check years
-    if (length(year) == 1) year <- c(year, year)
+    if (length(year) == 1) {
+      year <- c(year, year)
+    }
     stopifnot(length(year) == 2)
     year <- year[order(year)]
     #### 3. directory setup
@@ -540,7 +542,9 @@ download_geos <- function(
   #### 2. check for null parameters
   amadeus::check_for_null_parameters(mget(ls()))
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   #### 3. directory setup
@@ -1092,7 +1096,9 @@ download_merra2 <- function(
   amadeus::download_setup_dir(directory_to_save)
   directory_to_save <- amadeus::download_sanitize_path(directory_to_save)
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   #### check for null parameters
@@ -1428,12 +1434,14 @@ download_narr <- function(
   #### 2. check for null parameters
   amadeus::check_for_null_parameters(mget(ls()))
   #### check years
-  if (length(year) == 1) year <- c(year, year)
+  if (length(year) == 1) {
+    year <- c(year, year)
+  }
   stopifnot(length(year) == 2)
   year <- year[order(year)]
   #### 3. directory setup
   amadeus::download_setup_dir(directory_to_save)
-  directory_to_save <-amadeus:: download_sanitize_path(directory_to_save)
+  directory_to_save <- amadeus::download_sanitize_path(directory_to_save)
   #### 4. define years and months sequence
   if (any(nchar(year[1]) != 4, nchar(year[2]) != 4)) {
     stop("years should be 4-digit integers.\n")
@@ -1539,6 +1547,9 @@ download_narr <- function(
 #' @param remove_command logical(1).
 #' Remove (\code{TRUE}) or keep (\code{FALSE})
 #' the text file containing download commands.
+#' @param unzip logical(1). Unzip zip files. Default is \code{TRUE}.
+#' @param remove_zip logical(1). Remove zip files from directory_to_download.
+#' Default is \code{FALSE}.
 #' @param hash logical(1). By setting \code{TRUE} the function will return
 #' an \code{rlang::hash_file()} hash character corresponding to the
 #' downloaded files. Default is \code{FALSE}.
@@ -1570,6 +1581,8 @@ download_nlcd <- function(
   acknowledgement = FALSE,
   download = FALSE,
   remove_command = FALSE,
+  unzip = TRUE,
+  remove_zip = FALSE,
   hash = FALSE
 ) {
   #### 1. check for data download acknowledgement
@@ -1605,7 +1618,7 @@ download_nlcd <- function(
     collection_code,
     "_",
     year,
-    "_CU_C1V0.tif"
+    "_CU_C1V1.zip"
   )
   #### 9. build download file name
   download_name <- paste0(
@@ -1614,7 +1627,7 @@ download_nlcd <- function(
     collection_code,
     "_",
     year,
-    "_CU_C1V0.tif"
+    "_CU_C1V1.zip"
   )
   #### 10. build system command
   download_command <- paste0(
@@ -1648,6 +1661,17 @@ download_nlcd <- function(
     download = download,
     commands_txt = commands_txt,
     remove = remove_command
+  )
+  #### 16. end if unzip == FALSE
+  amadeus::download_unzip(
+    file_name = download_name,
+    directory_to_unzip = directory_to_save,
+    unzip = unzip
+  )
+  #### 18. remove zip files
+  amadeus::download_remove_zips(
+    remove = remove_zip,
+    download_name = download_name
   )
   return(amadeus::download_hash(hash, directory_to_save))
 }
@@ -2077,7 +2101,9 @@ download_hms <- function(
   #### 2. check for null parameters
   amadeus::check_for_null_parameters(mget(ls()))
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   #### 3. directory setup
@@ -2494,7 +2520,9 @@ download_modis <- function(
   amadeus::download_setup_dir(directory_to_save)
   directory_to_save <- amadeus::download_sanitize_path(directory_to_save)
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
 
@@ -2868,7 +2896,9 @@ download_tri <- function(
   amadeus::download_setup_dir(directory_to_save)
   directory_to_save <- amadeus::download_sanitize_path(directory_to_save)
   #### check years
-  if (length(year) == 1) year <- c(year, year)
+  if (length(year) == 1) {
+    year <- c(year, year)
+  }
   stopifnot(length(year) == 2)
   year <- year[order(year)]
   #### 3. define measurement data paths
@@ -3602,7 +3632,9 @@ download_gridmet <- function(
   #### check for null parameters
   amadeus::check_for_null_parameters(mget(ls()))
   #### check years
-  if (length(year) == 1) year <- c(year, year)
+  if (length(year) == 1) {
+    year <- c(year, year)
+  }
   stopifnot(length(year) == 2)
   year <- year[order(year)]
   #### directory setup
@@ -3746,7 +3778,9 @@ download_terraclimate <- function(
   #### check for null parameters
   amadeus::check_for_null_parameters(mget(ls()))
   #### check years
-  if (length(year) == 1) year <- c(year, year)
+  if (length(year) == 1) {
+    year <- c(year, year)
+  }
   stopifnot(length(year) == 2)
   year <- year[order(year)]
   #### directory setup

--- a/R/process.R
+++ b/R/process.R
@@ -895,6 +895,33 @@ process_nlcd <-
     if (length(nlcd_file) == 0) {
       stop("NLCD data not available for this year.")
     }
+    # NLCD C1V1 bug
+    # `.aux.xml` metadata file was causing `NA` values to be read as `NaN`,
+    # corrupting the factor/integer data values when used downstream.
+    # File is hidden with preceding `._` for retention but exlcusion in
+    # metadata definitions.
+    chr_aux_xml_path <- list.files(
+      path,
+      pattern = paste0(
+        "Annual_NLCD_(",
+        paste(product_codes, collapse = "|"),
+        ")_",
+        year,
+        "_.*\\.aux.xml"
+      ),
+      full.names = FALSE
+    )
+    chr_aux_xml_hide <- file.path(
+      amadeus::download_sanitize_path(path),
+      paste0("._", chr_aux_xml_path)
+    )
+    if (length(chr_aux_xml_path) == 1) {
+      message(paste0("Hiding corrupt ", chr_aux_xml_path, " metadata file."))
+      file.rename(
+        file.path(amadeus::download_sanitize_path(path), chr_aux_xml_path),
+        chr_aux_xml_hide
+      )
+    }
     nlcd <- terra::rast(nlcd_file, win = extent)
     terra::metags(nlcd) <- c(year = year)
     return(nlcd)
@@ -1577,7 +1604,9 @@ process_hms <- function(
   #### check for variable
   amadeus::check_for_null_parameters(mget(ls()))
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   #### identify file paths
@@ -1916,7 +1945,9 @@ process_narr <- function(
   #### check for variable
   amadeus::check_for_null_parameters(mget(ls()))
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   #### identify file paths
@@ -2170,7 +2201,9 @@ process_geos <-
     #### check for variable
     amadeus::check_for_null_parameters(mget(ls()))
     #### check dates
-    if (length(date) == 1) date <- c(date, date)
+    if (length(date) == 1) {
+      date <- c(date, date)
+    }
     stopifnot(length(date) == 2)
     date <- date[order(as.Date(date))]
     #### identify file paths
@@ -2369,7 +2402,9 @@ process_merra2 <-
     #### check for variable
     amadeus::check_for_null_parameters(mget(ls()))
     #### check dates
-    if (length(date) == 1) date <- c(date, date)
+    if (length(date) == 1) {
+      date <- c(date, date)
+    }
     stopifnot(length(date) == 2)
     date <- date[order(as.Date(date))]
     #### identify file paths
@@ -2559,7 +2594,9 @@ process_gridmet <- function(
   #### directory setup
   path <- amadeus::download_sanitize_path(path)
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   #### check for variable
@@ -2733,7 +2770,9 @@ process_terraclimate <- function(
   #### check for variable
   amadeus::check_for_null_parameters(mget(ls()))
   #### check dates
-  if (length(date) == 1) date <- c(date, date)
+  if (length(date) == 1) {
+    date <- c(date, date)
+  }
   stopifnot(length(date) == 2)
   date <- date[order(as.Date(date))]
   variable_checked <- amadeus::process_variable_codes(

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 `amadeus` is **a** **m**ech**a**nism for **d**ata, **e**nvironments, and **u**ser **s**etup for common environmental and climate health datasets in R. `amadeus` has been developed to improve access to and utility with large scale, publicly available environmental data in R.
 
+See the peer-reviewed publication, [Amadeus: Accessing and analyzing large scale environmental data in R](https://www.sciencedirect.com/science/article/pii/S1364815225000362), for full description and details.
+
+Cite `amadeus` as:
+Manware, M., Song, I., Marques, E. S., Kassien, M. A., Clark, L. P., & Messier, K. P. (2025). Amadeus: Accessing and analyzing large scale environmental data in R. Environmental Modelling & Software, 186, 106352.
+
 ## Installation
 
 `amadeus` can be installed from CRAN, or with `pak`.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ pak::pak("NIEHS/amadeus")
 | [NASA Goddard Earth Observing System Composition Forcasting (GEOS-CF)](https://gmao.gsfc.nasa.gov/GEOS_systems/) | netCDF | Atmosphere<br>Meteorology | Global |
 | [NOAA Hazard Mapping System Fire and Smoke Product](https://www.ospo.noaa.gov/products/land/hms.html#about) | Shapefile<br>KML | Wildfire Smoke | North America |
 | [NOAA NCEP[^4] North American Regional Reanalysis (NARR)](https://psl.noaa.gov/data/gridded/data.narr.html) | netCDF | Atmosphere<br>Meteorology | North America |
-| [OpenGeoHub Foundation OpenLandMap](https://opengeohub.org/about-openlandmap/) | GeoTIFF | Climate<br>Elevation<br>Soil<br>Land Use<br>Satellite | Global |
 | [Parameter Elevation Regression on Independent Slopes Model (PRISM)](https://elibrary.asabe.org/abstract.asp??JID=3&AID=3101&CID=t2000&v=43&i=6&T=1) | BIL<br>ASCII | Climate | United States |
 | [US EPA[^5] Air Data Pre-Generated Data Files](https://aqs.epa.gov/aqsweb/airdata/download_files.html) | CSV | Air Pollution | United States |
 | [US EPA Ecoregions](https://www.epa.gov/eco-research/ecoregions) | Shapefile | Climate Regions | North America |

--- a/man/download_aqs.Rd
+++ b/man/download_aqs.Rd
@@ -27,7 +27,7 @@ EPA pollutant parameter code. For details, please refer to
 Name of column containing POC values.
 Currently, no value other than \code{"daily"} works.}
 
-\item{year}{character(1 or 2). length of 4. Year or start/end years for downloading data.}
+\item{year}{integer(1 or 2). length of 4. Year or start/end years for downloading data.}
 
 \item{url_aqs_download}{character(1).
 URL to the AQS pre-generated datasets.}

--- a/man/download_gridmet.Rd
+++ b/man/download_gridmet.Rd
@@ -19,7 +19,7 @@ download_gridmet(
 for variable names and acronym codes. (Note: variable "Burning Index" has code "bi" and variable
 "Energy Release Component" has code "erc").}
 
-\item{year}{character(1 or 2). length of 4. Year or start/end years for downloading data.}
+\item{year}{integer(1 or 2). length of 4. Year or start/end years for downloading data.}
 
 \item{directory_to_save}{character(1). Directory(s) to save downloaded data
 files.}

--- a/man/download_narr.Rd
+++ b/man/download_narr.Rd
@@ -18,7 +18,7 @@ download_narr(
 \item{variables}{character. Variable(s) name acronym. See \href{https://ftp.cpc.ncep.noaa.gov/NARR/fixed/merged_land_AWIP32corrected.pdf}{List of Variables in NARR Files}
 for variable names and acronym codes.}
 
-\item{year}{character(1 or 2). length of 4. Year or start/end years for downloading data.}
+\item{year}{integer(1 or 2). length of 4. Year or start/end years for downloading data.}
 
 \item{directory_to_save}{character(1). Directory(s) to save downloaded data
 files.}

--- a/man/download_nei.Rd
+++ b/man/download_nei.Rd
@@ -25,7 +25,7 @@ for EPA DataCommons. Default is
 \item{certificate_url}{character(1). URL to certificate file. See notes for
 details.}
 
-\item{year}{Available years of NEI data.
+\item{year}{integer(1) Available years of NEI data.
 Default is \code{c(2017L, 2020L)}.}
 
 \item{directory_to_save}{character(1). Directory to save data. Two

--- a/man/download_nlcd.Rd
+++ b/man/download_nlcd.Rd
@@ -11,6 +11,8 @@ download_nlcd(
   acknowledgement = FALSE,
   download = FALSE,
   remove_command = FALSE,
+  unzip = TRUE,
+  remove_zip = FALSE,
   hash = FALSE
 )
 }
@@ -37,6 +39,11 @@ will download all of the requested data files.}
 \item{remove_command}{logical(1).
 Remove (\code{TRUE}) or keep (\code{FALSE})
 the text file containing download commands.}
+
+\item{unzip}{logical(1). Unzip zip files. Default is \code{TRUE}.}
+
+\item{remove_zip}{logical(1). Remove zip files from directory_to_download.
+Default is \code{FALSE}.}
 
 \item{hash}{logical(1). By setting \code{TRUE} the function will return
 an \code{rlang::hash_file()} hash character corresponding to the

--- a/man/download_terraclimate.Rd
+++ b/man/download_terraclimate.Rd
@@ -18,7 +18,7 @@ download_terraclimate(
 \item{variables}{character(1). Variable(s) name(s). See \href{https://climate.northwestknowledge.net/TERRACLIMATE/index_directDownloads.php}{TerraClimate Direct Downloads}
 for variable names and acronym codes.}
 
-\item{year}{character(1 or 2). length of 4. Year or start/end years for downloading data.}
+\item{year}{integer(1 or 2). length of 4. Year or start/end years for downloading data.}
 
 \item{directory_to_save}{character(1). Directory(s) to save downloaded data
 files.}

--- a/man/download_tri.Rd
+++ b/man/download_tri.Rd
@@ -14,7 +14,7 @@ download_tri(
 )
 }
 \arguments{
-\item{year}{character(1 or 2). length of 4. Year or start/end years for downloading data.}
+\item{year}{integer(1 or 2). length of 4. Year or start/end years for downloading data.}
 
 \item{directory_to_save}{character(1). Directory to download files.}
 

--- a/tests/container/container.def
+++ b/tests/container/container.def
@@ -33,7 +33,7 @@ From: rocker/geospatial:latest
 
     # Install R packages
     Rscript -e "install.packages(c('pak', 'rstac', 'testthat', 'covr', 'nanonext'))"
-    Rscript -e "pak::pkg_install('terra@1.8-50')"
+    Rscript -e "install.packages('terra')"
     Rscript -e "pak::pak('NIEHS/amadeus')"
 
 %environment

--- a/tests/container/test-coverage.R
+++ b/tests/container/test-coverage.R
@@ -1,0 +1,34 @@
+# Set and check library paths.
+.libPaths(grep("ddn", .libPaths(), value = TRUE, invert = TRUE))
+.libPaths()
+
+# Define temporary working directory.
+runnertemp <- file.path("/opt/tmp")
+dir.exists(runnertemp)
+
+# Create temporary working direectory.
+dir.create(
+  file.path(runnertemp, "package"),
+  showWarnings = FALSE,
+  recursive = TRUE
+)
+
+# Open connection.
+sink(paste0(runnertemp, "/package/testthat.Rout.res"))
+
+# Calculate package coverage.
+cov <- covr::package_coverage(quiet = FALSE)
+
+# Close connection.
+sink()
+
+# Coveragte as list.
+covd <- covr::coverage_to_list(cov)$totalcoverage
+
+# Save coverage table.
+write.table(
+  covd[length(covd)],
+  file = file.path(".", "local_cov.Rout"),
+  row.names = FALSE,
+  col.names = FALSE
+)

--- a/tests/container/test-local.sh
+++ b/tests/container/test-local.sh
@@ -9,7 +9,4 @@ export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 apptainer exec \
   --bind $PWD:/mnt \
   --bind /tmp:/opt/tmp \
-  tests/container/container.sif Rscript -e \
-  ".libPaths(); \
-   library(amadeus); \
-   covr::package_coverage(quiet = FALSE)"
+  container.sif Rscript test-coverage.R

--- a/tests/testthat/test-modis.R
+++ b/tests/testthat/test-modis.R
@@ -19,17 +19,19 @@ testthat::test_that("download_modis (MODIS-MOD09GA)", {
     date_start <- paste0(years[y], "-06-20")
     date_end <- paste0(years[y], "-06-24")
     # run download function
-    download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = version,
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = version,
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
     # define file path with commands
     commands_path <- paste0(
       directory_to_save,
@@ -47,9 +49,11 @@ testthat::test_that("download_modis (MODIS-MOD09GA)", {
     # check HTTP URL status
     url_status <- check_urls(urls = urls, size = 3L, method = "HEAD")
     # implement unit tests
-    test_download_functions(directory_to_save = directory_to_save,
-                            commands_path = commands_path,
-                            url_status = url_status)
+    test_download_functions(
+      directory_to_save = directory_to_save,
+      commands_path = commands_path,
+      url_status = url_status
+    )
     # remove file with commands after test
     file.remove(commands_path)
   }
@@ -67,17 +71,19 @@ testthat::test_that("download_modis (MODIS-MOD09GA + single date)", {
   nasa_earth_data_token <- "tOkEnPlAcEhOlDeR"
   directory_to_save <- paste0(tempdir(), "/mod/")
   date <- "2021-04-12"
-  download_data(dataset_name = "modis",
-                date = date,
-                product = product,
-                version = version,
-                horizontal_tiles = horizontal_tiles,
-                vertical_tiles = vertical_tiles,
-                nasa_earth_data_token = nasa_earth_data_token,
-                directory_to_save = directory_to_save,
-                acknowledgement = TRUE,
-                download = FALSE,
-                remove_command = FALSE)
+  download_data(
+    dataset_name = "modis",
+    date = date,
+    product = product,
+    version = version,
+    horizontal_tiles = horizontal_tiles,
+    vertical_tiles = vertical_tiles,
+    nasa_earth_data_token = nasa_earth_data_token,
+    directory_to_save = directory_to_save,
+    acknowledgement = TRUE,
+    download = FALSE,
+    remove_command = FALSE
+  )
   # define file path with commands
   commands_path <- paste0(
     directory_to_save,
@@ -95,9 +101,11 @@ testthat::test_that("download_modis (MODIS-MOD09GA + single date)", {
   # check HTTP URL status
   url_status <- check_urls(urls = urls, size = 3L, method = "HEAD")
   # implement unit tests
-  test_download_functions(directory_to_save = directory_to_save,
-                          commands_path = commands_path,
-                          url_status = url_status)
+  test_download_functions(
+    directory_to_save = directory_to_save,
+    commands_path = commands_path,
+    url_status = url_status
+  )
   # remove file with commands after test
   file.remove(commands_path)
   unlink(directory_to_save, recursive = TRUE)
@@ -117,47 +125,53 @@ testthat::test_that("download_modis (MODIS-MOD06L2)", {
   directory_to_save <- paste0(tempdir(), "/mod/")
 
   testthat::expect_error(
-    kax <- download_data(dataset_name = "modis",
-                    date = c(date_start, date_end),
-                    product = product,
-                    version = version,
-                    horizontal_tiles = horizontal_tiles,
-                    vertical_tiles = vertical_tiles,
-                    nasa_earth_data_token = nasa_earth_data_token,
-                    directory_to_save = directory_to_save,
-                    acknowledgement = TRUE,
-                    download = FALSE,
-                    mod06_links = NULL,
-                    remove_command = FALSE)
+    kax <- download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = version,
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      mod06_links = NULL,
+      remove_command = FALSE
+    )
   )
   # link check
   tdir <- tempdir()
   faux_urls <-
     rbind(
-      c(4387858920,
+      c(
+        4387858920,
         paste0(
           "/archive/allData/61/MOD06_L2/2019/049/",
           "MOD06_L2.A2019049.0720.061.2019049194350.hdf"
         ),
-        28267915)
+        28267915
+      )
     )
 
   faux_urls <- data.frame(faux_urls)
   mod06_scenes <- paste0(tdir, "/mod06_example.csv")
   write.csv(faux_urls, mod06_scenes, row.names = FALSE)
 
-  download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = version,
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  mod06_links = mod06_scenes,
-                  remove_command = FALSE)
+  download_data(
+    dataset_name = "modis",
+    date = c(date_start, date_end),
+    product = product,
+    version = version,
+    horizontal_tiles = horizontal_tiles,
+    vertical_tiles = vertical_tiles,
+    nasa_earth_data_token = nasa_earth_data_token,
+    directory_to_save = directory_to_save,
+    acknowledgement = TRUE,
+    download = FALSE,
+    mod06_links = mod06_scenes,
+    remove_command = FALSE
+  )
 
   # define file path with commands
   commands_path <- list.files(
@@ -172,9 +186,11 @@ testthat::test_that("download_modis (MODIS-MOD06L2)", {
   # check HTTP URL status
   url_status <- check_urls(urls = urls, size = 1L, method = "HEAD")
   # implement unit tests
-  test_download_functions(directory_to_save = directory_to_save,
-                          commands_path = commands_path,
-                          url_status = url_status)
+  test_download_functions(
+    directory_to_save = directory_to_save,
+    commands_path = commands_path,
+    url_status = url_status
+  )
   # remove file with commands after test
   file.remove(commands_path)
   unlink(directory_to_save, recursive = TRUE)
@@ -198,92 +214,104 @@ testthat::test_that("download_modis (expected errors)", {
 
   # no token
   testthat::expect_no_error(
-    download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = version,
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = version,
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
   )
 
   # no token
   testthat::expect_error(
-    download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = version,
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = NULL,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = version,
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = NULL,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
   )
 
   # year difference between date_start and date_end
   testthat::expect_error(
-    download_data(dataset_name = "modis",
-                  date = c(date_start, "2024-03-28"),
-                  product = "MOD11A1",
-                  version = version,
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, "2024-03-28"),
+      product = "MOD11A1",
+      version = version,
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
   )
 
   # null version
   testthat::expect_error(
-    download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = NULL,
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = NULL,
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
   )
 
   # invalid tile range (horizontal)
   testthat::expect_error(
-    download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = "61",
-                  horizontal_tiles = c(-13, -3),
-                  vertical_tiles = vertical_tiles,
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = "61",
+      horizontal_tiles = c(-13, -3),
+      vertical_tiles = vertical_tiles,
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
   )
 
   # invalid tile range (horizontal)
   testthat::expect_error(
-    download_data(dataset_name = "modis",
-                  date = c(date_start, date_end),
-                  product = product,
-                  version = "61",
-                  horizontal_tiles = horizontal_tiles,
-                  vertical_tiles = c(100, 102),
-                  nasa_earth_data_token = nasa_earth_data_token,
-                  directory_to_save = directory_to_save,
-                  acknowledgement = TRUE,
-                  download = FALSE,
-                  remove_command = FALSE)
+    download_data(
+      dataset_name = "modis",
+      date = c(date_start, date_end),
+      product = product,
+      version = "61",
+      horizontal_tiles = horizontal_tiles,
+      vertical_tiles = c(100, 102),
+      nasa_earth_data_token = nasa_earth_data_token,
+      directory_to_save = directory_to_save,
+      acknowledgement = TRUE,
+      download = FALSE,
+      remove_command = FALSE
+    )
   )
 
   # define file path with commands
@@ -303,9 +331,11 @@ testthat::test_that("download_modis (expected errors)", {
   # check HTTP URL status
   url_status <- check_urls(urls = urls, size = 2L, method = "HEAD")
   # implement unit tests
-  test_download_functions(directory_to_save = directory_to_save,
-                          commands_path = commands_path,
-                          url_status = url_status)
+  test_download_functions(
+    directory_to_save = directory_to_save,
+    commands_path = commands_path,
+    url_status = url_status
+  )
   # remove file with commands after test
   file.remove(commands_path)
   unlink(directory_to_save, recursive = TRUE)
@@ -316,10 +346,26 @@ testthat::test_that("download_modis (MOD + MYD products)", {
   withr::local_package("stringr")
   # function parameters
   products <- c(
-    "MOD09GA", "MYD09GA", "MOD09GQ", "MYD09GQ", "MOD09A1", "MYD09A1",
-    "MOD09Q1", "MYD09Q1", "MOD11A1", "MYD11A1", "MOD11A2", "MYD11A2",
-    "MOD11B1", "MYD11B1", "MOD13A1", "MYD13A1", "MOD13A2", "MYD13A2",
-    "MOD13A3", "MYD13A3"
+    "MOD09GA",
+    "MYD09GA",
+    "MOD09GQ",
+    "MYD09GQ",
+    "MOD09A1",
+    "MYD09A1",
+    "MOD09Q1",
+    "MYD09Q1",
+    "MOD11A1",
+    "MYD11A1",
+    "MOD11A2",
+    "MYD11A2",
+    "MOD11B1",
+    "MYD11B1",
+    "MOD13A1",
+    "MYD13A1",
+    "MOD13A2",
+    "MYD13A2",
+    "MOD13A3",
+    "MYD13A3"
   )
   version <- "61"
   horizontal_tiles <- c(10, 10)
@@ -390,21 +436,22 @@ testthat::test_that("process_modis_sds", {
     mcdtest <- process_modis_sds("MCD19A2")
   )
   testthat::expect_equal(
-    mcdtest, "(Optical_Depth)"
+    mcdtest,
+    "(Optical_Depth)"
   )
   testthat::expect_no_error(
     process_modis_sds("MCD19A2", "(cos|RelAZ|Angle)")
   )
   for (i in 1:3) {
     testthat::expect_equal(
-      process_modis_sds(txt_products[i]), txt_exp_output[i]
+      process_modis_sds(txt_products[i]),
+      txt_exp_output[i]
     )
   }
   testthat::expect_no_error(
     filt_other <- process_modis_sds("ignored", "(cos)")
   )
   testthat::expect_equal(filt_other, "(cos)")
-
 })
 
 
@@ -414,15 +461,21 @@ testthat::test_that("process_flatten_sds", {
   withr::local_options(list(sf_use_s2 = FALSE))
 
   mcd19 <- testthat::test_path(
-    "..", "testdata", "modis", "MCD19A2.A2021227.h11v05.061.2023149160635.hdf"
+    "..",
+    "testdata",
+    "modis",
+    "MCD19A2.A2021227.h11v05.061.2023149160635.hdf"
   )
   mod09 <- testthat::test_path(
-    "..", "testdata", "modis", "MOD09GA.A2021227.h11v05.061.2021229035936.hdf"
+    "..",
+    "testdata",
+    "modis",
+    "MOD09GA.A2021227.h11v05.061.2021229035936.hdf"
   )
 
   # main test: mcd19
   # expect warning for new strict terra/GDAL HDF4 warning
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     mcdaggr <-
       process_flatten_sds(
         path = mcd19,
@@ -440,7 +493,9 @@ testthat::test_that("process_flatten_sds", {
   # flatten error
   path_mod06 <-
     testthat::test_path(
-      "..", "testdata", "modis",
+      "..",
+      "testdata",
+      "modis",
       "MOD06_L2.A2021227.0320.061.2021227134022.hdf"
     )
 
@@ -480,7 +535,7 @@ testthat::test_that("process_modis_merge", {
       "../testdata/modis/",
       "MOD11A1.A2021227.h11v05.061.2021228105320.hdf"
     )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     process_modis_merge(
       path = path_mod11,
       date = "2021-08-15",
@@ -493,7 +548,7 @@ testthat::test_that("process_modis_merge", {
       "../testdata/modis/",
       "MOD13A2.A2021225.h11v05.061.2021320163751.hdf"
     )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     process_modis_merge(
       path = path_mod13,
       date = "2021-08-13",
@@ -507,7 +562,7 @@ testthat::test_that("process_modis_merge", {
       "../testdata/modis/",
       "MCD19A2.A2021227.h11v05.061.2023149160635.hdf"
     )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     process_modis_merge(
       path = path_mcd19,
       date = "2021-08-15",
@@ -521,7 +576,7 @@ testthat::test_that("process_modis_merge", {
       "../testdata/modis/",
       "MOD09GA.A2021227.h11v05.061.2021229035936.hdf"
     )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     process_modis_merge(
       path = path_mod09,
       date = "2021-08-15",
@@ -535,7 +590,7 @@ testthat::test_that("process_modis_merge", {
     pattern = "MOD13A2",
     full.names = TRUE
   )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     process_modis_merge(
       path = paths_mod13,
       date = "2021-08-13",
@@ -550,7 +605,6 @@ testthat::test_that("process_modis_merge", {
       fun_agg = 3L
     )
   )
-
 })
 
 
@@ -600,7 +654,6 @@ testthat::test_that("process_blackmarble*", {
       date = "2018~08~13"
     )
   )
-
 })
 
 
@@ -611,7 +664,9 @@ testthat::test_that("process_modis_warp + process_modis_swath", {
 
   path_mod06 <-
     testthat::test_path(
-      "..", "testdata", "modis",
+      "..",
+      "testdata",
+      "modis",
       "MOD06_L2.A2021227.0320.061.2021227134022.hdf"
     )
   path_mod06 <-
@@ -624,7 +679,9 @@ testthat::test_that("process_modis_warp + process_modis_swath", {
   )
   testthat::expect_s3_class(warped, "stars")
   testthat::expect_equal(
-    unname(stars::st_res(warped)[1]), 0.1, tolerance = 1e-6
+    unname(stars::st_res(warped)[1]),
+    0.1,
+    tolerance = 1e-6
   )
 
   path_mod06s <-
@@ -642,8 +699,6 @@ testthat::test_that("process_modis_warp + process_modis_swath", {
     )
   )
   testthat::expect_s4_class(warped4, "SpatRaster")
-
-
 })
 
 
@@ -653,7 +708,9 @@ testthat::test_that("process_modis (expected errors)", {
   withr::local_options(list(sf_use_s2 = FALSE))
   path_mod06 <-
     testthat::test_path(
-      "..", "testdata", "modis",
+      "..",
+      "testdata",
+      "modis",
       "MOD06_L2.A2021227.0320.061.2021227134022.hdf"
     )
   path_mod06e <-
@@ -713,10 +770,11 @@ testthat::test_that("calculate_modis", {
     )
   site_faux <-
     terra::vect(
-                site_faux,
-                geom = c("lon", "lat"),
-                keepgeom = FALSE,
-                crs = "EPSG:4326")
+      site_faux,
+      geom = c("lon", "lat"),
+      keepgeom = FALSE,
+      crs = "EPSG:4326"
+    )
 
   # case 1: standard mod11a1
   path_mod11 <-
@@ -724,7 +782,7 @@ testthat::test_that("calculate_modis", {
       "../testdata/modis/",
       "MOD11A1.A2021227.h11v05.061.2021228105320.hdf"
     )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     base_mod11 <-
       process_modis_merge(
         path = path_mod11,
@@ -804,16 +862,16 @@ testthat::test_that("calculate_modis", {
 
   # with geometry error
   testthat::expect_error(
-      calculate_modis(
-        from = path_mod11,
-        locs = sf::st_as_sf(site_faux),
-        preprocess = process_modis_merge,
-        package_list_add = c("MASS"),
-        export_list_add = c("aux"),
-        name_covariates = c("MOD_LSTNT_0_", "MOD_LSTDY_0_"),
-        subdataset = "(LST_)",
-        geom = TRUE
-      )
+    calculate_modis(
+      from = path_mod11,
+      locs = sf::st_as_sf(site_faux),
+      preprocess = process_modis_merge,
+      package_list_add = c("MASS"),
+      export_list_add = c("aux"),
+      name_covariates = c("MOD_LSTNT_0_", "MOD_LSTDY_0_"),
+      subdataset = "(LST_)",
+      geom = TRUE
+    )
   )
 
   # case 2: swath mod06l2
@@ -938,7 +996,6 @@ testthat::test_that("calculate_modis", {
   )
   testthat::expect_s4_class(calc_vnp46_terra, "SpatVector")
 
-
   # with geometry sf
   testthat::expect_no_error(
     suppressWarnings(
@@ -1035,7 +1092,7 @@ testthat::test_that("calculate_modis", {
       "../testdata/modis/",
       "MCD19A2.A2021227.h11v05.061.2023149160635.hdf"
     )
-  testthat::expect_warning(
+  testthat::expect_no_warning(
     mcd_merge <-
       process_modis_merge(
         path = path_mcd19,
@@ -1055,7 +1112,7 @@ testthat::test_that("calculate_modis", {
   )
 
   # test calculate_modis_daily directly with geometry terra
-  testthat::expect_no_error( 
+  testthat::expect_no_error(
     calc_mod_terra <- calculate_modis_daily(
       from = mcd_merge,
       date = "2021-08-15",
@@ -1084,7 +1141,11 @@ testthat::test_that("calculate_modis", {
     calculate_modis(from = site_faux)
   )
   testthat::expect_error(
-    calculate_modis(from = path_mod11, product = "MOD11A1", locs = list(1, 2, 3))
+    calculate_modis(
+      from = path_mod11,
+      product = "MOD11A1",
+      locs = list(1, 2, 3)
+    )
   )
   testthat::expect_error(
     calculate_modis(
@@ -1117,6 +1178,5 @@ testthat::test_that("calculate_modis", {
   )
   testthat::expect_s3_class(flushed, "data.frame")
   testthat::expect_true(unlist(flushed[, 2]) == -99999)
-
 })
 # nolint end

--- a/tests/testthat/test-nlcd.R
+++ b/tests/testthat/test-nlcd.R
@@ -35,7 +35,8 @@ testthat::test_that("download_nlcd", {
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
       download = FALSE,
-      remove_command = FALSE
+      remove_command = FALSE,
+      unzip = FALSE
     )
     # define file path with commands
     commands_path <- paste0(

--- a/tests/testthat/test-nlcd.R
+++ b/tests/testthat/test-nlcd.R
@@ -500,7 +500,7 @@ testthat::test_that("integration across *_nlcd functions", {
   ##############################################################################
   # Import
   testthat::expect_no_error(
-    nlcd_c1v1 <- amadeus::process_nlcd(path = dir, year = 1985)
+    nlcd_c1v1 <- amadeus::process_nlcd(path = directory, year = 1985)
   )
   testthat::expect_identical(terra::metags(nlcd_c1v1)[2, 2], "1985")
 


### PR DESCRIPTION
Patch `*_nlcd` functions

`download_nlcd`
- Update base URL for new C1V1 product version

`process_nlcd`
- Hide the `.aux.xml` file which was storing `NA` values as `NaN` and corrupting downstream calculations

`calculate_nlcd`
- Query standard NLCD short names based on `value` for `mode = "terra"` and `mode = "exact"`

Implemented a live download, process, calculate integration test for NLCD. Will take a little while (~2 min for download), but will ensure seamless integration when working with new product versions.