### PR TITLE
NASA MODIS download logic fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: amadeus
 Title: Accessing and Analyzing Large-Scale Environmental Data
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: c(
     person(given = "Mitchell", family = "Manware", role = c("aut", "ctb"), comment = c(ORCID = "0009-0003-6440-6106")),
     person(given = "Insang", family = "Song", role = c("aut", "ctb"), comment = c(ORCID = "0000-0001-8732-3256")),
@@ -33,7 +33,8 @@ Imports:
     nhdplusTools,
     archive,
     collapse,
-    Rdpack
+    Rdpack,
+    jsonlite
 Suggests:
     covr,
     withr,

--- a/R/download.R
+++ b/R/download.R
@@ -2390,7 +2390,7 @@ download_koppen_geiger <- function(
 #'  input/modis/raw/\{version\}/\{product\}/\{year\}/\{day_of_year\}.
 #' @param product character(1).
 #' One of `c("MOD09GA", "MOD11A1", "MOD06_L2", "MCD19A2", "MOD13A2", "VNP46A2")`
-#' @param version character(1). Default is `"61"`, meaning v061.
+#' @param version character(1). Default is `"061"`, meaning v061.
 #' @param horizontal_tiles integer(2). Horizontal tile numbers
 #' `c({start}, {end})`. Default is `c(7, 13)`.
 #' @param vertical_tiles integer(2). Vertical tile numbers
@@ -2398,11 +2398,13 @@ download_koppen_geiger <- function(
 #' @param nasa_earth_data_token character(1).
 #'  Token for downloading data from NASA. Should be set before
 #'  trying running the function.
-#' @param mod06_links character(1). CSV file path to MOD06_L2 download links
-#' from [NASA LAADS MOD06_L2](https://ladsweb.modaps.eosdis.nasa.gov/search/order/2/MOD06_L2--61). Default is `NULL`.
 #' @param date character(1 or 2). length of 10. Date or start/end dates for downloading data.
 #' Format "YYYY-MM-DD" (ex. January 1, 2018 = `"2018-01-01"`). Note: ignored if
 #' \code{product == "MOD06_L2"}.
+#' @param extent numeric(4). Bounding box for downloading data.
+#' Format is `c(min_lon, max_lon, min_lat, max_lat)`.
+#' Default is `c(-125, 22, -64, 50)`, approximately covering the
+#' continental United States.
 #' @param directory_to_save character(1). Directory to save data.
 #' @param acknowledgement logical(1). By setting \code{TRUE} the
 #' user acknowledges that the data downloaded using this function may be very
@@ -2437,13 +2439,15 @@ download_koppen_geiger <- function(
 #' \dontrun{
 #' ## NOTE: Examples are wrapped in `/dontrun{}` to avoid sharing sensitive
 #' ##       NASA EarthData tokden information.
+#' vec_extent <- c(-80, 35, -75, 40)
 #' # example with MOD09GA product
 #' download_modis(
 #'   product = "MOD09GA",
-#'   version = "61",
+#'   version = "061",
 #'   horizontal_tiles = c(8, 8),
 #'   vertical_tiles = c(4, 4),
 #'   date = "2024-01-01",
+#'   extent = vec_extent,
 #'   nasa_earth_data_token = "./pathtotoken/token.txt",
 #'   directory_to_save = tempdir(),
 #'   acknowledgement = TRUE,
@@ -2453,15 +2457,11 @@ download_koppen_geiger <- function(
 #' # example with MOD06_L2 product
 #' download_modis(
 #'   product = "MOD06_L2",
-#'   version = "61",
+#'   version = "6.1",
 #'   horizontal_tiles = c(8, 8),
 #'   vertical_tiles = c(4, 4),
+#'   extent = vec_extent,
 #'   date = "2024-01-01",
-#'   mod06_links =
-#'     system.file(
-#'       "extdata", "nasa", "LAADS_query.2024-08-02T12_49.csv",
-#'       package = "amadeus"
-#'     ),
 #'   nasa_earth_data_token = "./pathtotoken/token.txt",
 #'   directory_to_save = tempdir(),
 #'   acknowledgement = TRUE,
@@ -2471,10 +2471,11 @@ download_koppen_geiger <- function(
 #' # example with VNP46A2 product
 #' download_modis(
 #'   product = "VNP46A2",
-#'   version = "61",
+#'   version = "5200",
 #'   horizontal_tiles = c(8, 8),
 #'   vertical_tiles = c(4, 4),
 #'   date = "2024-01-01",
+#'   extent = vec_extent,
 #'   nasa_earth_data_token = "./pathtotoken/token.txt",
 #'   directory_to_save = tempdir(),
 #'   acknowledgement = TRUE,MOD09GA
@@ -2510,12 +2511,12 @@ download_modis <- function(
     "MCD19A2",
     "VNP46A2"
   ),
-  version = "61",
+  version = "061",
   horizontal_tiles = c(7, 13),
   vertical_tiles = c(3, 6),
-  mod06_links = NULL,
   nasa_earth_data_token = NULL,
   date = c("2023-09-01", "2023-09-01"),
+  extent = c(-125, 22, -64, 50),
   directory_to_save = NULL,
   acknowledgement = FALSE,
   download = FALSE,
@@ -2547,12 +2548,12 @@ download_modis <- function(
     }
   }
 
-  #### 5. check for version
+  #### 5. check for version -- may not be necessary in 1.3.2+
   if (is.null(version)) {
     stop("Please select a data version.\n")
   }
 
-  #### 6. check for valid horizontal tiles
+  #### 6. check for valid horizontal tiles -- to be deprecated
   if (!all(horizontal_tiles %in% seq(0, 35))) {
     stop("Horizontal tiles are not in the proper range [0, 35].\n")
   }
@@ -2577,185 +2578,71 @@ download_modis <- function(
   tiles_vertical <-
     sprintf("v%02d", tiles_vertical)
 
-  #### 8. define requested tiles
+  #### 8. define requested tiles -- to be deprecated
   tiles_df <- expand.grid(
     h = tiles_horizontal,
     v = tiles_vertical
   )
-  tiles_requested <-
-    paste0(tiles_df$h, tiles_df$v)
 
-  #### 9. Reuse ladsweb home url
-  ladsurl <- "https://ladsweb.modaps.eosdis.nasa.gov/"
-  version <- ifelse(startsWith(product, "VNP"), "5200", version)
-
-  #### 11. define date sequence
+  #### 9. define date sequence
   date_sequence <- amadeus::generate_date_sequence(
     date[1],
     date[2],
     sub_hyphen = FALSE
   )
 
-  #### 10. MOD06_L2 manual input
-  if (product == "MOD06_L2") {
-    mod06l2_url1 <-
-      "https://ladsweb.modaps.eosdis.nasa.gov/"
-    mod06l2_url2 <-
-      "search/order/4/MOD06_L2--61/"
-    mod06l2_url3 <-
-      "%s..%s/DNB/-130,52,-60,20"
-    mod06l2_url_template <-
-      paste0(mod06l2_url1, mod06l2_url2, mod06l2_url3)
-    mod06l2_full <-
-      sprintf(mod06l2_url_template, date[1], date[2])
-
-    if (is.null(mod06_links)) {
-      stop(paste(
-        "Please provide a CSV file path to MOD06_L2 download links.
-                 You may download it from the link:\n",
-        mod06l2_full,
-        "\nTime length up to one month is recommended.\n"
-      ))
-    }
-
-    date_julian <- format(date_sequence, "%Y%j")
-
-    #### 10-1. Parse urls in csv
-    file_url <- read.csv(mod06_links)
-    file_url <- unlist(file_url[, 2])
-    download_url <- gsub("^/", "", file_url)
-
-    download_url <- download_url[
-      grep(paste0("A(", paste(date_julian, collapse = "|"), ")"), download_url)
-    ]
-
-    #### 10-2. Parse dates from csv
-    # file_dates <-
-    #   regmatches(
-    #     file_url,
-    #     regexpr("[2][0-2][0-9]{2,2}[0-3][0-9]{2,2}", file_url)
-    #   )
-    # file_dates <- as.integer(file_dates)
-    # date_start <- as.Date(as.character(min(file_dates)), format = "%Y%j")
-    # date_end <- as.Date(as.character(max(file_dates)), format = "%Y%j")
-
-    # Extract download names from file_url using splitter
-    # download_name <- sapply(strsplit(download_url, "/"), `[`, 10)
-    download_name <- unlist(
-      lapply(
-        download_url,
-        function(x) tail(strsplit(x, "/")[[1]], 1)
-      )
+  #### 10. warning message for excessive query (CMR limit)
+  dt_date <- as.Date(date)
+  if (diff(dt_date) > 31) {
+    warning(
+      "Date range is greater than 31 days.",
+      "The results may not include all dates in the range."
     )
-
-    # Create directory structure with julian dates
-    dir_substr <- paste0(
-      substr(download_name, 11, 14),
-      "/",
-      substr(download_name, 15, 17),
-      "/"
-    )
-
-    #### 10-3. initiate "..._wget_commands.txt" file
-    commands_txt <- paste0(
-      directory_to_save,
-      product,
-      "_",
-      date_julian[1],
-      "_",
-      date_julian[length(date_julian)],
-      "_wget_commands.txt"
-    )
-
-    #### 10-4. write download_command
-    download_command <- paste0(
-      "wget ",
-      "-e robots=off -np -R .html,.tmp ",
-      "-nH --cut-dirs=3 ",
-      "--continue ",
-      "--tries=20 ",
-      "--retry-connrefused ",
-      "--waitretry=30 ",
-      "--timeout=60 ",
-      "--retry-on-http-error=500,502,503,504 ",
-      "--limit-rate=10M ",
-      "--random-wait ",
-      "--wait=2 ",
-      "--no-clobber ",
-      "--keep-session-cookies ",
-      "--header='Authorization: Bearer ",
-      nasa_earth_data_token,
-      "' ",
-      "'",
-      download_url,
-      "' ",
-      "-O '",
-      directory_to_save,
-      dir_substr,
-      download_name,
-      "'",
-      "\n"
-    )
-
-    #### filter commands to non-existing files
-    download_command <- download_command[
-      which(
-        !file.exists(paste0(directory_to_save, dir_substr, download_name)) |
-          file.size(paste0(directory_to_save, dir_substr, download_name)) == 0
-      )
-    ]
-
-    new_dirs <- unique(
-      sprintf("%s%s", directory_to_save, dir_substr)
-    )
-
-    lapply(
-      new_dirs,
-      function(x) dir.create(x, recursive = TRUE, showWarnings = FALSE)
-    )
-
-    # avoid any possible errors by removing existing command files
-    amadeus::download_sink(commands_txt)
-    #### cat command only if file does not already exist
-    cat(download_command)
-    sink()
-
-    amadeus::download_run(
-      download = download,
-      commands_txt = commands_txt,
-      remove = remove_command
-    )
-
-    message("Requests were processed.\n")
-    return(amadeus::download_hash(hash, directory_to_save))
   }
 
-  # In a certain year, list all available dates
-  year <- as.character(substr(date[1], 1, 4))
-  filedir_year_url <-
-    paste0(
-      ladsurl,
-      "archive/allData/",
-      version,
-      "/",
-      product,
-      "/",
-      year
-    )
+  #### 11. version fix
+  if (product == "MOD06_L2") {
+    str_version <- "6.1"
+  } else if (product == "VNP46A2") {
+    str_version <- NULL
+  } else {
+    str_version <- version
+  }
 
-  list_available_d <-
-    rvest::read_html(filedir_year_url) |>
-    rvest::html_elements("tr") |>
-    rvest::html_attr("data-name")
-  # no conditional assignment at this moment.
+  #### 12. Query CMR
+  chr_extent <- paste(extent, collapse = ",")
+  resp <-
+    httr2::request(
+      "https://cmr.earthdata.nasa.gov/search/granules.json"
+    ) |>
+    httr2::req_url_query(
+      short_name = product,
+      version = str_version,
+      temporal = paste(date[1], date[2], sep = ","),
+      bounding_box = chr_extent,
+      page_size = 2000
+    ) |>
+    httr2::req_perform()
+  granules <- resp |> httr2::resp_body_json()
+
+  # Extract data URLs
+  urls <- sapply(granules$feed$entry, function(g) {
+    links <- g$links
+    data_link <- Filter(function(l) grepl("data#", l$rel), links)
+    if (length(data_link) > 0) data_link[[1]]$href else NA
+  })
+  urls <- urls[!is.na(urls)]
+
+  list_available_d <- stringi::stri_extract(urls, regex = "A2[0-9]{6,6}")
+  list_available_d <- unique(gsub("A", "", list_available_d))
 
   # remove NAs
-  # 12. Queried year's available days
+  # 13. Queried year's available days
   date_sequence <- list_available_d[!is.na(list_available_d)]
   date_sequence_i <- as.integer(date_sequence)
   # Queried dates to integer range
-  date_start_i <- as.integer(strftime(date[1], "%j"))
-  date_end_i <- as.integer(strftime(date[2], "%j"))
+  date_start_i <- as.integer(strftime(date[1], "%Y%j"))
+  date_end_i <- as.integer(strftime(date[2], "%Y%j"))
   date_range_julian <- seq(date_start_i, date_end_i)
   date_sequence_in <- (date_sequence_i %in% date_range_julian)
 
@@ -2766,7 +2653,7 @@ download_modis <- function(
   ))
   date_sequence <- date_sequence[date_sequence_in]
 
-  #### 13. initiate "..._wget_commands.txt" file
+  #### 14. initiate "..._wget_commands.txt" file
   commands_txt <- paste0(
     directory_to_save,
     product,
@@ -2779,103 +2666,55 @@ download_modis <- function(
 
   # avoid any possible errors by removing existing command files
   amadeus::download_sink(commands_txt)
-  #### 14. append download commands to text file
-  for (d in seq_along(date_sequence)) {
-    day <- date_sequence[d]
-    filedir_url <-
-      paste0(
-        filedir_year_url,
-        "/",
-        day
-      )
+  #### 15. append download commands to text file
+  download_name <- basename(urls)
+  # Main wget run
+  download_command <- paste0(
+    "wget ",
+    "-e robots=off -np -R .html,.tmp ",
+    "-nH --cut-dirs=3 ",
+    "--continue ",
+    "--tries=20 ",
+    "--retry-connrefused ",
+    "--waitretry=30 ",
+    "--timeout=60 ",
+    "--retry-on-http-error=500,502,503,504 ",
+    "--limit-rate=10M ",
+    "--random-wait ",
+    "--wait=2 ",
+    "--no-clobber ",
+    "--keep-session-cookies ",
+    "--header='Authorization: Bearer ",
+    nasa_earth_data_token,
+    "' ",
+    "'",
+    urls,
+    # filelist_sub,
+    "' ",
+    "-O '",
+    directory_to_save,
+    # dir_substr,
+    download_name,
+    "'",
+    "\n"
+  )
 
-    filelist <-
-      rvest::read_html(filedir_url) |>
-      rvest::html_elements("tr") |>
-      rvest::html_attr("data-path")
-
-    filelist_sub <-
-      grep(
-        paste0("(", paste(tiles_requested, collapse = "|"), ")"),
-        filelist,
-        value = TRUE
-      )
-
-    download_name <- sapply(
-      strsplit(filelist_sub, paste0("/", day, "/")),
-      `[`,
-      2
+  #### filter commands to non-existing files
+  download_command <- download_command[
+    which(
+      !file.exists(paste0(directory_to_save, download_name)) |
+        file.size(paste0(directory_to_save, download_name)) == 0
     )
+  ]
 
-    dir_str_julian <-
-      lapply(
-        download_name,
-        function(x) strsplit(x, paste0(product, ".A"))[[1]][2]
-      )
+  #### 16. concatenate and print download commands to "..._wget_commands.txt"
+  #### cat command only if file does not already exist
+  cat(download_command)
 
-    dir_substr <- paste0(
-      substr(dir_str_julian, 1, 4),
-      "/",
-      substr(dir_str_julian, 5, 7),
-      "/"
-    )
-
-    new_dirs <- unique(
-      sprintf("%s%s", directory_to_save, dir_substr)
-    )
-
-    lapply(
-      new_dirs,
-      function(x) dir.create(x, recursive = TRUE, showWarnings = FALSE)
-    )
-
-    # Main wget run
-    download_command <- paste0(
-      "wget ",
-      "-e robots=off -np -R .html,.tmp ",
-      "-nH --cut-dirs=3 ",
-      "--continue ",
-      "--tries=20 ",
-      "--retry-connrefused ",
-      "--waitretry=30 ",
-      "--timeout=60 ",
-      "--retry-on-http-error=500,502,503,504 ",
-      "--limit-rate=10M ",
-      "--random-wait ",
-      "--wait=2 ",
-      "--no-clobber ",
-      "--keep-session-cookies ",
-      "--header='Authorization: Bearer ",
-      nasa_earth_data_token,
-      "' ",
-      "'",
-      filelist_sub,
-      "' ",
-      "-O '",
-      directory_to_save,
-      dir_substr,
-      download_name,
-      "'",
-      "\n"
-    )
-
-    #### filter commands to non-existing files
-    download_command <- download_command[
-      which(
-        !file.exists(paste0(directory_to_save, dir_substr, download_name)) |
-          file.size(paste0(directory_to_save, dir_substr, download_name)) == 0
-      )
-    ]
-
-    #### 15. concatenate and print download commands to "..._wget_commands.txt"
-    #### cat command only if file does not already exist
-    cat(download_command)
-  }
-
-  #### 16. finish "..._wget_commands.txt"
+  #### 17. finish "..._wget_commands.txt"
   sink(file = NULL)
 
-  #### 17.
+  #### 18.
   amadeus::download_run(
     download = download,
     commands_txt = commands_txt,

--- a/R/download_auxiliary.R
+++ b/R/download_auxiliary.R
@@ -344,17 +344,28 @@ generate_time_sequence <-
 #' @description
 #' Check if provided URL returns HTTP status 200 or 206.
 #' @param url Download URL to be checked.
+#' @param earthdata_token Earthdata token for authentication.
 #' @author Insang Song; Mitchell Manware; Kyle Messier
 #' @importFrom httr2 request req_perform resp_status
 #' @return logical object
 #' @keywords internal auxiliary
 #' @export
 check_url_status <- function(
-  url
+  url,
+  earthdata_token = NULL
 ) {
   http_status_ok <- c(200, 206)
+  if (!is.null(earthdata_token)) {
+    earthdata_token <- Sys.getenv("EARTHDATA_TOKEN")
+    if (is.null(earthdata_token) || earthdata_token == "") {
+      stop("Earthdata token is not defined.\n")
+    }
+  }
   status <- url |>
     httr2::request() |>
+    httr2::req_method("HEAD") |>
+    httr2::req_headers(Authorization = paste0("Bearer ", earthdata_token)) |>
+    httr2::req_error(is_error = \(resp) FALSE) |>
     httr2::req_perform() |>
     httr2::resp_status()
   Sys.sleep(1)

--- a/man/check_url_status.Rd
+++ b/man/check_url_status.Rd
@@ -4,10 +4,12 @@
 \alias{check_url_status}
 \title{Check HTTP status}
 \usage{
-check_url_status(url)
+check_url_status(url, earthdata_token = NULL)
 }
 \arguments{
 \item{url}{Download URL to be checked.}
+
+\item{earthdata_token}{Earthdata token for authentication.}
 }
 \value{
 logical object

--- a/man/download_modis.Rd
+++ b/man/download_modis.Rd
@@ -9,12 +9,12 @@ download_modis(
     "MOD09Q1", "MYD09Q1", "MOD11A1", "MYD11A1", "MOD11A2", "MYD11A2", "MOD11B1",
     "MYD11B1", "MOD13A1", "MYD13A1", "MOD13A2", "MYD13A2", "MOD13A3", "MYD13A3",
     "MOD06_L2", "MCD19A2", "VNP46A2"),
-  version = "61",
+  version = "061",
   horizontal_tiles = c(7, 13),
   vertical_tiles = c(3, 6),
-  mod06_links = NULL,
   nasa_earth_data_token = NULL,
   date = c("2023-09-01", "2023-09-01"),
+  extent = c(-125, 22, -64, 50),
   directory_to_save = NULL,
   acknowledgement = FALSE,
   download = FALSE,
@@ -26,16 +26,13 @@ download_modis(
 \item{product}{character(1).
 One of \code{c("MOD09GA", "MOD11A1", "MOD06_L2", "MCD19A2", "MOD13A2", "VNP46A2")}}
 
-\item{version}{character(1). Default is \code{"61"}, meaning v061.}
+\item{version}{character(1). Default is \code{"061"}, meaning v061.}
 
 \item{horizontal_tiles}{integer(2). Horizontal tile numbers
 \code{c({start}, {end})}. Default is \code{c(7, 13)}.}
 
 \item{vertical_tiles}{integer(2). Vertical tile numbers
 \code{c({start}, {end})}. Default is \code{c(3, 6)}.}
-
-\item{mod06_links}{character(1). CSV file path to MOD06_L2 download links
-from \href{https://ladsweb.modaps.eosdis.nasa.gov/search/order/2/MOD06_L2--61}{NASA LAADS MOD06_L2}. Default is \code{NULL}.}
 
 \item{nasa_earth_data_token}{character(1).
 Token for downloading data from NASA. Should be set before
@@ -44,6 +41,11 @@ trying running the function.}
 \item{date}{character(1 or 2). length of 10. Date or start/end dates for downloading data.
 Format "YYYY-MM-DD" (ex. January 1, 2018 = \code{"2018-01-01"}). Note: ignored if
 \code{product == "MOD06_L2"}.}
+
+\item{extent}{numeric(4). Bounding box for downloading data.
+Format is \code{c(min_lon, max_lon, min_lat, max_lat)}.
+Default is \code{c(-125, 22, -64, 50)}, approximately covering the
+continental United States.}
 
 \item{directory_to_save}{character(1). Directory to save data.}
 
@@ -89,13 +91,15 @@ input/modis/raw/\{version\}/\{product\}/\{year\}/\{day_of_year\}.
 \dontrun{
 ## NOTE: Examples are wrapped in `/dontrun{}` to avoid sharing sensitive
 ##       NASA EarthData tokden information.
+vec_extent <- c(-80, 35, -75, 40)
 # example with MOD09GA product
 download_modis(
   product = "MOD09GA",
-  version = "61",
+  version = "061",
   horizontal_tiles = c(8, 8),
   vertical_tiles = c(4, 4),
   date = "2024-01-01",
+  extent = vec_extent,
   nasa_earth_data_token = "./pathtotoken/token.txt",
   directory_to_save = tempdir(),
   acknowledgement = TRUE,
@@ -105,15 +109,11 @@ download_modis(
 # example with MOD06_L2 product
 download_modis(
   product = "MOD06_L2",
-  version = "61",
+  version = "6.1",
   horizontal_tiles = c(8, 8),
   vertical_tiles = c(4, 4),
+  extent = vec_extent,
   date = "2024-01-01",
-  mod06_links =
-    system.file(
-      "extdata", "nasa", "LAADS_query.2024-08-02T12_49.csv",
-      package = "amadeus"
-    ),
   nasa_earth_data_token = "./pathtotoken/token.txt",
   directory_to_save = tempdir(),
   acknowledgement = TRUE,
@@ -123,10 +123,11 @@ download_modis(
 # example with VNP46A2 product
 download_modis(
   product = "VNP46A2",
-  version = "61",
+  version = "5200",
   horizontal_tiles = c(8, 8),
   vertical_tiles = c(4, 4),
   date = "2024-01-01",
+  extent = vec_extent,
   nasa_earth_data_token = "./pathtotoken/token.txt",
   directory_to_save = tempdir(),
   acknowledgement = TRUE,MOD09GA

--- a/tests/testthat/test-modis.R
+++ b/tests/testthat/test-modis.R
@@ -6,11 +6,12 @@
 ##### download_modis
 testthat::test_that("download_modis (MODIS-MOD09GA)", {
   withr::local_package("httr2")
-  withr::local_package("stringr")
+  withr::local_package("stringi")
+  withr::local_package("jsonlite")
   # function parameters
   years <- 2020
   product <- "MOD09GA"
-  version <- "61"
+  version <- "061"
   horizontal_tiles <- c(12, 13)
   vertical_tiles <- c(5, 6)
   nasa_earth_data_token <- Sys.getenv("EARTHDATA_TOKEN")
@@ -26,6 +27,7 @@ testthat::test_that("download_modis (MODIS-MOD09GA)", {
       version = version,
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = vertical_tiles,
+      extent = c(-124, 25, -105, 40),
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -66,7 +68,7 @@ testthat::test_that("download_modis (MODIS-MOD09GA + single date)", {
   withr::local_package("stringr")
   # function parameters
   product <- "MOD09GA"
-  version <- "61"
+  version <- "061"
   horizontal_tiles <- c(12, 13)
   vertical_tiles <- c(5, 6)
   nasa_earth_data_token <- Sys.getenv("EARTHDATA_TOKEN")
@@ -79,6 +81,7 @@ testthat::test_that("download_modis (MODIS-MOD09GA + single date)", {
     version = version,
     horizontal_tiles = horizontal_tiles,
     vertical_tiles = vertical_tiles,
+    extent = c(-124, 25, -105, 40),
     nasa_earth_data_token = nasa_earth_data_token,
     directory_to_save = directory_to_save,
     acknowledgement = TRUE,
@@ -119,47 +122,48 @@ testthat::test_that("download_modis (MODIS-MOD06L2)", {
   withr::local_package("stringr")
   # function parameters
   product <- "MOD06_L2"
-  version <- "61"
+  version <- "061"
   date_start <- "2019-02-18"
-  date_end <- "2019-02-18"
+  date_end <- "2019-02-28"
   nasa_earth_data_token <- Sys.getenv("EARTHDATA_TOKEN")
   horizontal_tiles <- c(8, 10)
   vertical_tiles <- c(4, 5)
   directory_to_save <- paste0(tempdir(), "/mod/")
 
-  testthat::expect_error(
-    kax <- download_data(
-      dataset_name = "modis",
-      date = c(date_start, date_end),
-      product = product,
-      version = version,
-      horizontal_tiles = horizontal_tiles,
-      vertical_tiles = vertical_tiles,
-      nasa_earth_data_token = nasa_earth_data_token,
-      directory_to_save = directory_to_save,
-      acknowledgement = TRUE,
-      download = FALSE,
-      mod06_links = NULL,
-      remove_command = FALSE
-    )
+  # testthat::expect_error(
+  kax <- download_data(
+    dataset_name = "modis",
+    date = c(date_start, date_end),
+    product = product,
+    version = version,
+    horizontal_tiles = horizontal_tiles,
+    vertical_tiles = vertical_tiles,
+    extent = c(-124, 25, -105, 40),
+    nasa_earth_data_token = nasa_earth_data_token,
+    directory_to_save = directory_to_save,
+    acknowledgement = TRUE,
+    download = FALSE,
+    mod06_links = NULL,
+    remove_command = FALSE
   )
+  # )
   # link check
-  tdir <- tempdir()
-  faux_urls <-
-    rbind(
-      c(
-        4387858920,
-        paste0(
-          "https://ladsweb.modaps.eosdis.nasa.gov/api/v2/content/archives/",
-          "MOD06_L2.A2019049.0720.061.2019049194350.hdf"
-        ),
-        28267915
-      )
-    )
+  # tdir <- tempdir()
+  # faux_urls <-
+  #   rbind(
+  #     c(
+  #       4387858920,
+  #       paste0(
+  #         "https://ladsweb.modaps.eosdis.nasa.gov/api/v2/content/archives/",
+  #         "MOD06_L2.A2019049.0720.061.2019049194350.hdf"
+  #       ),
+  #       28267915
+  #     )
+  #   )
 
-  faux_urls <- data.frame(faux_urls)
-  mod06_scenes <- paste0(tdir, "/mod06_example.csv")
-  write.csv(faux_urls, mod06_scenes, row.names = FALSE)
+  # faux_urls <- data.frame(faux_urls)
+  # mod06_scenes <- paste0(tdir, "/mod06_example.csv")
+  # write.csv(faux_urls, mod06_scenes, row.names = FALSE)
 
   download_data(
     dataset_name = "modis",
@@ -168,11 +172,12 @@ testthat::test_that("download_modis (MODIS-MOD06L2)", {
     version = version,
     horizontal_tiles = horizontal_tiles,
     vertical_tiles = vertical_tiles,
+    extent = c(-124, 25, -105, 40),
     nasa_earth_data_token = nasa_earth_data_token,
     directory_to_save = directory_to_save,
     acknowledgement = TRUE,
     download = FALSE,
-    mod06_links = mod06_scenes,
+    # mod06_links = mod06_scenes,
     remove_command = FALSE
   )
 
@@ -185,8 +190,8 @@ testthat::test_that("download_modis (MODIS-MOD06L2)", {
   # import commands
   commands <- read_commands(commands_path = commands_path)[[5]]
   # extract urls
-  urls <- extract_urls(commands = commands, position = 10)[[1]] %>%
-    gsub("'", "", .)
+  urls <- extract_urls(commands = commands, position = 10)[[1]] |>
+    gsub(pattern = "'", replacement = "")
   # check HTTP URL status
   url_status <- check_urls(urls = urls, size = 1L)
   # implement unit tests
@@ -208,13 +213,15 @@ testthat::test_that("download_modis (expected errors)", {
   years <- 2020
   product <- c("MOD09GA", "MOD11A1", "MOD13A2", "MCD19A2")
   product <- sample(product, 1L)
-  version <- "61"
+  version <- "061"
   horizontal_tiles <- c(12, 13)
   vertical_tiles <- c(5, 6)
   nasa_earth_data_token <- Sys.getenv("EARTHDATA_TOKEN")
   directory_to_save <- paste0(tempdir(), "/mod/")
   date_start <- paste0(years, "-06-25")
   date_end <- paste0(years, "-06-28")
+  vec_extent <- c(-124, 25, -105, 40)
+
 
   # no token
   testthat::expect_no_error(
@@ -225,6 +232,7 @@ testthat::test_that("download_modis (expected errors)", {
       version = version,
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = vertical_tiles,
+      extent = vec_extent,
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -242,6 +250,7 @@ testthat::test_that("download_modis (expected errors)", {
       version = version,
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = vertical_tiles,
+      extent = vec_extent,
       nasa_earth_data_token = NULL,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -259,6 +268,7 @@ testthat::test_that("download_modis (expected errors)", {
       version = version,
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = vertical_tiles,
+      extent = vec_extent,
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -276,6 +286,7 @@ testthat::test_that("download_modis (expected errors)", {
       version = NULL,
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = vertical_tiles,
+      extent = vec_extent,
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -293,6 +304,7 @@ testthat::test_that("download_modis (expected errors)", {
       version = "61",
       horizontal_tiles = c(-13, -3),
       vertical_tiles = vertical_tiles,
+      extent = vec_extent,
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -310,6 +322,7 @@ testthat::test_that("download_modis (expected errors)", {
       version = "61",
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = c(100, 102),
+      extent = vec_extent,
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -372,13 +385,14 @@ testthat::test_that("download_modis (MOD + MYD products)", {
     "MOD13A3",
     "MYD13A3"
   )
-  version <- "61"
+  version <- "061"
   horizontal_tiles <- c(10, 10)
   vertical_tiles <- c(4, 5)
   nasa_earth_data_token <- Sys.getenv("EARTHDATA_TOKEN")
   directory_to_save <- paste0(tempdir(), "/mod/")
   date_start <- "2021-06-01"
   date_end <- "2021-06-30"
+  vec_extent <- c(-124, 25, -105, 40)
   for (p in seq_along(products)) {
     cat("Testing product:", products[p], "\n")
     # run download function
@@ -389,6 +403,7 @@ testthat::test_that("download_modis (MOD + MYD products)", {
       version = version,
       horizontal_tiles = horizontal_tiles,
       vertical_tiles = vertical_tiles,
+      extent = vec_extent,
       nasa_earth_data_token = nasa_earth_data_token,
       directory_to_save = directory_to_save,
       acknowledgement = TRUE,
@@ -1141,7 +1156,7 @@ testthat::test_that("calculate_modis", {
     )
   )
   site_faux2 <- site_faux
-  #site_faux2[, 4] <- NULL
+  # site_faux2[, 4] <- NULL
 
   path_mcd19 <-
     testthat::test_path(


### PR DESCRIPTION
- Bumped version to 1.3.1
- `download_modis()`
  - Shifted from the hard-coded LAADS endpoints to file links retrieved from the Common Metadata Repository
  - added extent
  - changed default `version` argument value ("61" to "061")
  - removed `mod06_links` argument
  - TODO: deprecate horizontal and vertical tiles
- `check_urls()`
  - Only check HEAD to expedite HTTP code checks
  - Per changes in `download_modis()`, NASA bearer token is used in this function to avoid 401 (Unauthorized) errors
- Tests for two functions