### PR TITLE
blackmarble test fix

### DIFF
--- a/R/calculate_covariates_auxiliary.R
+++ b/R/calculate_covariates_auxiliary.R
@@ -776,7 +776,7 @@ calculate_modis_daily <- function(
 # In R/calculate_covariates.R, starting at line 1148
 collapse_nlcd <- function(
   data,
-  mode = c("terra", "extract"),
+  mode = c("terra", "exact"),
   locs = NULL,
   locs_id = "site_id"
 ) {

--- a/R/process.R
+++ b/R/process.R
@@ -535,7 +535,7 @@ process_blackmarble <- function(
 
         terra::crs(vnp_) <- terra::crs(crs)
         terra::ext(vnp_) <- unlist(tile_ext)
-        return(vnp_)
+        vnp_
       },
       vnp_today,
       filepaths_today_tiles_list,

--- a/man/collapse_nlcd.Rd
+++ b/man/collapse_nlcd.Rd
@@ -6,7 +6,7 @@
 \usage{
 collapse_nlcd(
   data,
-  mode = c("terra", "extract"),
+  mode = c("terra", "exact"),
   locs = NULL,
   locs_id = "site_id"
 )

--- a/tests/testthat/test-modis.R
+++ b/tests/testthat/test-modis.R
@@ -644,23 +644,20 @@ testthat::test_that("process_blackmarble*", {
     process_blackmarble_corners(hrange = c(99, 104))
   )
 
-  testthat::expect_warning(
-    vnp46_proc <- process_blackmarble(
-      path = path_vnp46[1],
-      tile_df = corn,
-      date = "2018-08-13"
-    )
+  vnp46_proc <- process_blackmarble(
+    path = path_vnp46[1],
+    tile_df = corn,
+    date = "2018-08-13"
   )
+
   testthat::expect_s4_class(vnp46_proc, "SpatRaster")
   testthat::expect_equal(terra::nlyr(vnp46_proc), 1L)
 
-  testthat::expect_warning(
-    vnp46_proc2 <- process_blackmarble(
-      path = path_vnp46[1],
-      tile_df = corn,
-      subdataset = c(3L, 5L),
-      date = "2018-08-13"
-    )
+  vnp46_proc2 <- process_blackmarble(
+    path = path_vnp46[1],
+    tile_df = corn,
+    subdataset = c(3L, 5L),
+    date = "2018-08-13"
   )
 
   testthat::expect_s4_class(vnp46_proc2, "SpatRaster")
@@ -885,7 +882,7 @@ testthat::test_that("calculate_modis", {
         )
     )
   )
-  testthat::expect_true("sf" %in% class(calc_mod11_sf))
+  testthat::expect_true(inherits(calc_mod11_sf, "sf"))
 
   # with geometry error
   testthat::expect_error(
@@ -1001,7 +998,7 @@ testthat::test_that("calculate_modis", {
         )
     )
   )
-  testthat::expect_true("sf" %in% class(calc_mod06_sf))
+  testthat::expect_true(inherits(calc_mod06_sf, "sf"))
 
   # with geometry error
   testthat::expect_error(
@@ -1022,12 +1019,10 @@ testthat::test_that("calculate_modis", {
       "VNP46",
       full.names = TRUE
     )
-  testthat::expect_warning(
-    base_vnp <- process_blackmarble(
-      path = path_vnp46,
-      date = "2018-08-13",
-      tile_df = process_blackmarble_corners(c(9, 10), c(5, 5))
-    )
+  base_vnp <- process_blackmarble(
+    path = path_vnp46,
+    date = "2018-08-13",
+    tile_df = process_blackmarble_corners(c(9, 10), c(5, 5))
   )
 
   testthat::expect_no_error(
@@ -1204,7 +1199,7 @@ testthat::test_that("calculate_modis", {
       geom = "sf"
     )
   )
-  testthat::expect_true("sf" %in% class(calc_mod_sf))
+  testthat::expect_true(inherits(calc_mod_sf, "sf"))
 
   testthat::expect_error(
     calculate_modis(from = site_faux, scale = "* 1")
@@ -1236,7 +1231,7 @@ testthat::test_that("calculate_modis", {
       tile_df = process_blackmarble_corners(c(9, 10), c(5, 5))
     )
   )
-  testthat::expect_warning(
+  # testthat::expect_warning(
     flushed <- calculate_modis(
       from = path_vnp46,
       locs = site_faux,
@@ -1246,7 +1241,7 @@ testthat::test_that("calculate_modis", {
       radius = c(-1000, 0L),
       scale = "* 1"
     )
-  )
+  # )
   testthat::expect_s3_class(flushed, "data.frame")
   testthat::expect_true(unlist(flushed[, 2]) == -99999)
 

--- a/tests/testthat/test-nlcd.R
+++ b/tests/testthat/test-nlcd.R
@@ -506,7 +506,7 @@ testthat::test_that("integration across *_nlcd functions", {
 
   ##############################################################################
   nc <- terra::project(
-    terra::vect(system.file("shape/nc.shp", package = "sf")),
+    ncv,
     terra::crs(nlcd_c1v1)
   )
 


### PR DESCRIPTION
- No actual warning message was expected in calculate_blackmarble()
- collapse_nlcd(): fixed mode option (extract to exact)