### PR TITLE
Test related patch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # 1.3
-- Fixed depcreated file paths for NLCD, MODIS, and Ecoregions datasets
+- Fixed deprecated file paths for NLCD, MODIS, and Ecoregions datasets
 - Removed the certificate verification from ecoregion download which is not needed anymore
 - For NASA datasets MODIS, VIIRS, and Geos-CF, added additional options to prevent API throttling 
-- httr upgraded to httr2 
+- httr upgraded to httr2
+- Modified internal URL status check function for general use
 
 # 1.2
 - `future` and `future.apply` dependencies were removed

--- a/R/download.R
+++ b/R/download.R
@@ -2833,10 +2833,12 @@ download_tri <- function(
 #' @description
 #' The \code{download_nei()} function accesses and downloads road emissions data from the [U.S Environmental Protection Agency's (EPA) National Emissions Inventory (NEI)](https://www.epa.gov/air-emissions-inventories/national-emissions-inventory-nei).
 # nolint end
-#' @param epa_certificate_path character(1). Path to the certificate file
-#' for EPA DataCommons. Default is
+#' @param epa_certificate_path <TO BE DEPRECATED> character(1).
+#' Path to the certificate file for EPA DataCommons. Default is
 #' 'extdata/cacert_gaftp_epa.pem' under the package installation path.
-#' @param certificate_url character(1). URL to certificate file. See notes for
+#' Use `system.file()` to get the full path.
+#' @param certificate_url <TO BE DEPRECATED>
+#' character(1). URL to certificate file. See notes for
 #' details.
 #' @param year integer(1) Available years of NEI data.
 #' Default is \code{c(2017L, 2020L)}.
@@ -2888,10 +2890,7 @@ download_tri <- function(
 #' }
 #' @export
 download_nei <- function(
-  epa_certificate_path = system.file(
-    "extdata/cacert_gaftp_epa.pem",
-    package = "amadeus"
-  ),
+  epa_certificate_path = NULL,
   certificate_url = "http://cacerts.digicert.com/DigiCertGlobalG2TLSRSASHA2562020CA1-1.crt",
   year = c(2017L, 2020L),
   directory_to_save = NULL,
@@ -2910,10 +2909,11 @@ download_nei <- function(
   directory_to_save <- directories[2]
 
   #### 5. define download URL
-  amadeus::download_epa_certificate(
-    epa_certificate_path = epa_certificate_path,
-    certificate_url = certificate_url
-  )
+  # DEPRECATED: certificate download step
+  # amadeus::download_epa_certificate(
+  #   epa_certificate_path = epa_certificate_path,
+  #   certificate_url = certificate_url
+  # )
 
   #### 3. define measurement data paths
   url_download_base <- "https://gaftp.epa.gov/air/nei/%d/data_summaries/"
@@ -2928,16 +2928,24 @@ download_nei <- function(
     c("2017neiApr_onroad_byregions.zip", "2020nei_onroad_byregion.zip")
   download_names <- paste0(directory_to_download, download_names_file)
   #### 4. build download command
+  # 1.3.1.1: use curl
   download_commands <-
     paste0(
-      "wget --ca-certificate=",
-      epa_certificate_path,
-      " ",
-      download_urls,
-      " -O ",
+      "curl -s -o ",
       download_names,
+      " --url ",
+      download_urls,
       "\n"
     )
+    # paste0(
+    #   "wget --ca-certificate=",
+    #   epa_certificate_path,
+    #   " ",
+    #   download_urls,
+    #   " -O ",
+    #   download_names,
+    #   "\n"
+    # )
   #### filter commands to non-existing files
   download_commands <- download_commands[
     which(
@@ -2951,7 +2959,7 @@ download_nei <- function(
     paste(year, collapse = "-"),
     "_",
     Sys.Date(),
-    "_wget_commands.txt"
+    "_curl_commands.txt"
   )
   amadeus::download_sink(commands_txt)
   #### 6. concatenate and print download commands to "..._curl_commands.txt"

--- a/R/download_auxiliary.R
+++ b/R/download_auxiliary.R
@@ -357,17 +357,21 @@ check_url_status <- function(
   http_status_ok <- c(200, 206)
   if (!is.null(earthdata_token)) {
     earthdata_token <- Sys.getenv("EARTHDATA_TOKEN")
-    if (is.null(earthdata_token) || earthdata_token == "") {
-      stop("Earthdata token is not defined.\n")
-    }
+    status <- url |>
+      httr2::request() |>
+      httr2::req_method("HEAD") |>
+      httr2::req_headers(Authorization = paste0("Bearer ", earthdata_token)) |>
+      httr2::req_error(is_error = \(resp) FALSE) |>
+      httr2::req_perform() |>
+      httr2::resp_status()
+  } else {
+    status <- url |>
+      httr2::request() |>
+      httr2::req_method("HEAD") |>
+      httr2::req_error(is_error = \(resp) FALSE) |>
+      httr2::req_perform() |>
+      httr2::resp_status()
   }
-  status <- url |>
-    httr2::request() |>
-    httr2::req_method("HEAD") |>
-    httr2::req_headers(Authorization = paste0("Bearer ", earthdata_token)) |>
-    httr2::req_error(is_error = \(resp) FALSE) |>
-    httr2::req_perform() |>
-    httr2::resp_status()
   Sys.sleep(1)
   return(status %in% http_status_ok)
 }

--- a/man/download_nei.Rd
+++ b/man/download_nei.Rd
@@ -5,7 +5,7 @@
 \title{Download road emissions data}
 \usage{
 download_nei(
-  epa_certificate_path = system.file("extdata/cacert_gaftp_epa.pem", package = "amadeus"),
+  epa_certificate_path = NULL,
   certificate_url =
     "http://cacerts.digicert.com/DigiCertGlobalG2TLSRSASHA2562020CA1-1.crt",
   year = c(2017L, 2020L),
@@ -18,12 +18,16 @@ download_nei(
 )
 }
 \arguments{
-\item{epa_certificate_path}{character(1). Path to the certificate file
-for EPA DataCommons. Default is
-'extdata/cacert_gaftp_epa.pem' under the package installation path.}
+\item{epa_certificate_path}{\if{html}{\out{<TO BE DEPRECATED>}} character(1).
+Path to the certificate file for EPA DataCommons. Default is
+'extdata/cacert_gaftp_epa.pem' under the package installation path.
+Use \code{system.file()} to get the full path.}
 
-\item{certificate_url}{character(1). URL to certificate file. See notes for
-details.}
+\item{certificate_url}{\if{html}{\out{
+<TO BE DEPRECATED>
+character(1). URL to certificate file. See notes for
+details.
+}}}
 
 \item{year}{integer(1) Available years of NEI data.
 Default is \code{c(2017L, 2020L)}.}

--- a/tests/testthat/test-nei.R
+++ b/tests/testthat/test-nei.R
@@ -9,10 +9,10 @@ testthat::test_that("download_nei", {
   withr::local_package("stringr")
   # function parameters
   directory_to_save <- paste0(tempdir(), "/nei/")
-  certificate <- system.file(
-    "extdata/cacert_gaftp_epa.pem",
-    package = "amadeus"
-  )
+  # certificate <- system.file(
+  #   "extdata/cacert_gaftp_epa.pem",
+  #   package = "amadeus"
+  # )
   # run download function
   year <- c(2017L, 2020L)
   download_data(
@@ -22,7 +22,7 @@ testthat::test_that("download_nei", {
     download = FALSE,
     year = year,
     remove_command = FALSE,
-    epa_certificate_path = certificate
+    # epa_certificate_path = certificate
   )
   # expect sub-directories to be created
   testthat::expect_true(
@@ -41,16 +41,16 @@ testthat::test_that("download_nei", {
     paste(year, collapse = "-"),
     "_",
     Sys.Date(),
-    "_wget_commands.txt"
+    "_curl_commands.txt"
   )
 
   # import commands
   commands <- read_commands(commands_path = commands_path)
   # extract urls
-  urls <- extract_urls(commands = commands, position = 3)
+  urls <- extract_urls(commands = commands, position = 6)
   # check HTTP URL status
   url_status <-
-    httr::HEAD(urls[1], config = httr::config(cainfo = certificate))
+    httr::HEAD(urls[1])#, config = httr::config(cainfo = certificate))
   url_status <- url_status$status_code
   # implement unit tests
   test_download_functions(
@@ -69,10 +69,10 @@ testthat::test_that("download_nei (live)", {
   withr::local_package("stringr")
   # function parameters
   directory_to_save <- paste0(tempdir(), "/nei/")
-  certificate <- system.file(
-    "extdata/cacert_gaftp_epa.pem",
-    package = "amadeus"
-  )
+  # certificate <- system.file(
+  #   "extdata/cacert_gaftp_epa.pem",
+  #   package = "amadeus"
+  # )
   # run download function
   year <- c(2017L, 2020L)
   testthat::expect_no_error(
@@ -83,7 +83,7 @@ testthat::test_that("download_nei (live)", {
       download = TRUE,
       year = year,
       remove_command = FALSE,
-      epa_certificate_path = certificate,
+      # epa_certificate_path = certificate,
       unzip = TRUE
     )
   )
@@ -109,12 +109,12 @@ testthat::test_that("download_nei (expected errors)", {
   # function parameters
   tdir <- tempdir()
   directory_to_save <- paste0(tempdir(), "/epa/")
-  certificate <- file.path(tdir, "cacert_gaftp_epa.pem")
+  # certificate <- file.path(tdir, "cacert_gaftp_epa.pem")
   # remove if there is a preexisting file
-  if (file.exists(certificate)) {
-    file.remove(certificate)
-    file.remove(gsub("pem", "crt", certificate))
-  }
+  # if (file.exists(certificate)) {
+  #   file.remove(certificate)
+  #   file.remove(gsub("pem", "crt", certificate))
+  # }
 
   # run download function
   year <- c(2017L)
@@ -125,8 +125,7 @@ testthat::test_that("download_nei (expected errors)", {
       acknowledgement = TRUE,
       download = FALSE,
       year = year,
-      remove_command = FALSE,
-      epa_certificate_path = certificate
+      remove_command = FALSE
     )
   )
   # define file path with commands
@@ -136,7 +135,7 @@ testthat::test_that("download_nei (expected errors)", {
     paste(year, collapse = "-"),
     "_",
     Sys.Date(),
-    "_wget_commands.txt"
+    "_curl_commands.txt"
   )
   # remove file with commands after test
   testthat::expect_true(file.exists(commands_path))

--- a/tests/testthat/test-nlcd.R
+++ b/tests/testthat/test-nlcd.R
@@ -505,6 +505,8 @@ testthat::test_that("integration across *_nlcd functions", {
   testthat::expect_identical(terra::metags(nlcd_c1v1)[2, 2], "1985")
 
   ##############################################################################
+  ncpath <- system.file("gpkg/nc.gpkg", package = "sf")
+  ncv <- terra::vect(ncpath)
   nc <- terra::project(
     ncv,
     terra::crs(nlcd_c1v1)


### PR DESCRIPTION
- Removed certificate verification in `download_nei()` and its tests
- `download_nei()` uses curl instead of wget
- Generalized URL check function