### PR TITLE
Fix NetCDF time parsing and GridMET download reuse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: amadeus
 Title: Accessing and Analyzing Large-Scale Environmental Data
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: c(
     person(given = "Mitchell", family = "Manware", role = c("aut", "ctb"), comment = c(ORCID = "0009-0003-6440-6106")),
     person(given = "Insang", family = "Song", role = c("aut", "ctb"), comment = c(ORCID = "0000-0001-8732-3256")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# amadeus 2.0.2
+
+- Fixed process_gridmet() to use valid native NetCDF time metadata from terra::time() when available and fall back to layer-name parsing when needed
+- Fixed download_gridmet() to handle cases where all requested files already exist locally without calling download_run_method() with an empty URL list
+
 # amadeus 2.0.0
 ## Major updates to code base - breaking changes have been minmized but please report if 1.3.x versions are not working as expected
 

--- a/R/download.R
+++ b/R/download.R
@@ -3537,14 +3537,24 @@ download_gridmet <- function(
   }
 
   #### Download files using httr2
-  download_result <- amadeus::download_run_method(
-    urls = all_urls,
-    destfiles = all_destfiles,
-    token = NULL,
-    show_progress = show_progress,
-    max_tries = max_tries,
-    rate_limit = rate_limit
-  )
+  if (length(all_urls) > 0) {
+    download_result <- amadeus::download_run_method(
+      urls = all_urls,
+      destfiles = all_destfiles,
+      token = NULL,
+      show_progress = show_progress,
+      max_tries = max_tries,
+      rate_limit = rate_limit
+    )
+  } else {
+    message("All files already exist. Nothing to download.\n")
+
+    download_result <- list(
+      success = 0,
+      failed = 0,
+      skipped = length(variables_list) * length(years)
+    )
+  }
 
   if (hash) {
     return(amadeus::download_hash(hash = TRUE, directory_to_save))

--- a/R/process.R
+++ b/R/process.R
@@ -3729,7 +3729,7 @@ process_gridmet <- function(
       ),
       "...\n"
     ))
-    
+
     existing_time <- terra::time(data_year)
 
     if (

--- a/R/process.R
+++ b/R/process.R
@@ -3729,11 +3729,22 @@ process_gridmet <- function(
       ),
       "...\n"
     ))
-    terra::time(data_year) <- amadeus::process_parse_ncdf_day_codes(
-      layer_names = names(data_year),
-      source = "gridmet",
-      origin = "1900-01-01"
-    )
+    
+    existing_time <- terra::time(data_year)
+
+    if (
+      length(existing_time) == terra::nlyr(data_year) &&
+      !all(is.na(existing_time))
+    ) {
+      terra::time(data_year) <- existing_time
+    } else {
+      terra::time(data_year) <- amadeus::process_parse_ncdf_day_codes(
+        layer_names = names(data_year),
+        source = "gridmet",
+        origin = "1900-01-01"
+      )
+    }
+
     names(data_year) <- paste0(
       variable_checked,
       "_",


### PR DESCRIPTION
## Summary
* `process_gridmet()` fails on GridMET NetCDF files with layer names such as `precipitation_amount_1`, even though valid dates are already available through `terra::time()`. The fix preserves native NetCDF time metadata when available and uses the existing parser as a fallback.
* `download_gridmet()` fails with `No URLs provided for download` when all requested files already exist. The fix skips the download call when there are no new files to download.

## Testing
Verified that GridMET data can be downloaded, reused on subsequent runs, and successfully processed for a requested date range.